### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ tasks.whenTaskAdded((tas -> {
                 java.nio.file.Path notNeededDirectory = it.externalLibNativeLibs
                         .getFiles()
                         .stream()
+                        // for React Native 0.71, the file value now contains "jetified-react-android"
                         .filter(file -> file.toString().contains("jetified-react-native"))
                         .findAny()
                         .orElse(null)


### PR DESCRIPTION
Current `README.md` android configuration will cause build to fail on RN 0.71 due to file name change. This PR add suggestion for new file name